### PR TITLE
breaking change: Gorpo.services expose node information

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,9 +1,0 @@
-root = true
-
-[*.{ex,exs}]
-end_of_line = lf
-charset = utf-8
-indent_size = 2
-indent_style = space
-trim_trailing_whitespace = true
-insert_final_newline = true

--- a/lib/gorpo/consul.ex
+++ b/lib/gorpo/consul.ex
@@ -337,7 +337,19 @@ defmodule Gorpo.Consul do
   end
 
   defp load_service(name, data) do
-    service = Gorpo.Service.load(name, Map.fetch!(data, "Service"))
+    node = Gorpo.Node.load(Map.fetch!(data, "Node"))
+    service_address =
+      fn address ->
+        if address == "" or is_nil(address) do
+          node.address
+        else
+          address
+        end
+      end
+    service =
+      name
+      |> Gorpo.Service.load(Map.fetch!(data, "Service"))
+      |> Map.update!(:address, service_address)
     result =
       data
       |> Map.fetch!("Checks")
@@ -346,9 +358,9 @@ defmodule Gorpo.Consul do
 
     case result do
       [] ->
-        {service, nil}
+        {node, service, nil}
       [status] ->
-        {service, status}
+        {node, service, status}
     end
   end
 end

--- a/lib/gorpo/node.ex
+++ b/lib/gorpo/node.ex
@@ -1,0 +1,102 @@
+# Copyright (c) 2016, Diego Vinicius e Souza All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+defmodule Gorpo.Node do
+  @moduledoc """
+  Consul node information.
+
+  <dl>
+    <dt>id</dt>
+    <dd>the node id</dd>
+
+    <dt>node</dt>
+    <dd>the name of the consul node</dd>
+
+    <dt>address</dt>
+    <dd>the ip address of the consul node</dd>
+
+    <dt>tagged_addresses</dt>
+    <dd>the list of explicit LAN and WAN IP addresses for the agent</dd>
+  </dl>
+  """
+
+  defstruct [
+    id: nil,
+    node: nil,
+    address: nil,
+    tagged_addresses: %{
+      lan: nil, wan: nil
+    }
+  ]
+
+  @type t :: %__MODULE__{
+    id: String.t | nil,
+    node: String.t | nil,
+    address: String.t | nil,
+    tagged_addresses: %{lan: String.t | nil, wan: String.t | nil}
+  }
+
+  @spec dump(t) :: %{String.t => term}
+  @doc """
+  Encodes the node into a map that once json-encoded matches the Consul
+  node structure.
+  """
+  def dump(node) do
+    %{
+      "ID" => node.id,
+      "Node" => node.node,
+      "Address" => node.address,
+      "TaggedAddresses" => %{
+        "lan" => node.tagged_addresses.lan,
+        "wan" => node.tagged_addresses.wan
+      }
+    }
+  end
+
+  @spec load(map) :: t
+  @doc """
+  Parses a Consul service definition into a `Service` struct.
+  """
+  def load(data) do
+    tagged_addresses = Map.get(data, "TaggedAddresses", %{})
+    %__MODULE__{
+      id: data["ID"],
+      node: data["Node"],
+      address: data["Address"],
+      tagged_addresses: %{
+        lan: tagged_addresses["lan"],
+        wan: tagged_addresses["wan"]
+      }
+    }
+  end
+end
+
+defimpl Poison.Encoder, for: Gorpo.Node do
+  def encode(node, opts) do
+    node
+    |> Gorpo.Node.dump()
+    |> Poison.Encoder.encode(opts)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Gorpo.Mixfile do
   use Mix.Project
 
-  @version "0.1.1"
+  @version "0.2.0"
 
   def project do
     [


### PR DESCRIPTION
the function returns the node associated with the service which breaks
the previous interface. Also, if the service does not define an
addresse we copy it from the node address value.